### PR TITLE
fix: use first found line for package position

### DIFF
--- a/lua/pubspec-assist.lua
+++ b/lua/pubspec-assist.lua
@@ -57,6 +57,7 @@ local icons = {
 ---@field error table
 ---@field name string
 ---@field type number
+---@field ui table
 
 ---@table<number, table<number, Package>>
 local packages = {}
@@ -178,7 +179,9 @@ local function get_lnum_lookup(lines)
       local key = line:match(".-:")
       if key then
         local package_name = vim.trim(key:gsub(":", ""))
-        lookup[package_name] = lnum
+        if not lookup[package_name] then
+          lookup[package_name] = lnum
+        end
       end
     end
   end


### PR DESCRIPTION
pubspec may contain plugin configuration at the bottom, i.e.
```
flutter_native_splash:
  image: assets/images/splash.png
```
This fix will pick first found line as package location